### PR TITLE
Update dynamic lookup to reflect new changes in PyRadiomics

### DIFF
--- a/SlicerRadiomics/SlicerRadiomics.py
+++ b/SlicerRadiomics/SlicerRadiomics.py
@@ -4,7 +4,7 @@ import vtk, qt, ctk, slicer
 from slicer.ScriptedLoadableModule import *
 import logging
 import SimpleITK as sitk
-from radiomics import featureextractor
+from radiomics import featureextractor, getFeatureClasses
 
 #
 # SlicerRadiomics
@@ -93,7 +93,7 @@ class SlicerRadiomicsWidget(ScriptedLoadableModuleWidget):
     self.featuresButtonGroup.exclusive = False
 
     # Get the feature classes dynamically
-    self.features = featureextractor.RadiomicsFeaturesExtractor.getFeatureClasses().keys()
+    self.features = getFeatureClasses().keys()
     # Create a checkbox for each feature
     featureButtons = {}
     for feature in self.features:


### PR DESCRIPTION
`getFeatureClasses` function is now moved to the radiomics namespace and is not a part of `featureextractor` anymore. Change the lookup of featureclasses in SlicerRadiomics accordingly.