### PR TITLE
Change extension name to "Radiomics"

### DIFF
--- a/SlicerRadiomics/SlicerRadiomics.py
+++ b/SlicerRadiomics/SlicerRadiomics.py
@@ -19,7 +19,7 @@ class SlicerRadiomics(ScriptedLoadableModule):
 
   def __init__(self, parent):
     ScriptedLoadableModule.__init__(self, parent)
-    self.parent.title = 'SlicerRadiomics'
+    self.parent.title = 'Radiomics'
     self.parent.categories = ['Informatics']
     self.parent.dependencies = []
     self.parent.contributors = ['Nicole Aucion (BWH)']


### PR DESCRIPTION
Change the name of the extension in Slicer. Project name remains SlicerRadiomics, but as discussed with @hugoaerts, the "Slicer" part of the name is redundant inside slicer.