### PR TITLE
Support standalone packaging

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,6 +39,15 @@ add_subdirectory(SlicerRadiomics)
 ## NEXT_MODULE
 
 #-----------------------------------------------------------------------------
+# Install extension python packages
+
+install(
+    DIRECTORY "${python_pyradiomics_DIR}/"
+    DESTINATION ${Slicer_INSTALL_ROOT}
+    COMPONENT RuntimeLibraries
+    )
+
+#-----------------------------------------------------------------------------
 set(CPACK_INSTALL_CMAKE_PROJECTS "${CPACK_INSTALL_CMAKE_PROJECTS};${CMAKE_BINARY_DIR};${EXTENSION_NAME};ALL;/")
 #set(CPACK_INSTALL_CMAKE_PROJECTS "${CPACK_INSTALL_CMAKE_PROJECTS};${Foo_DIR};Foo;RuntimeLibraries;/")
 include(${Slicer_EXTENSION_CPACK})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,7 +43,7 @@ add_subdirectory(SlicerRadiomics)
 
 install(
     DIRECTORY "${python_pyradiomics_DIR}/"
-    DESTINATION ${Slicer_INSTALL_ROOT}
+    DESTINATION ${Slicer_INSTALL_ROOT}${Slicer_BUNDLE_EXTENSIONS_LOCATION}
     COMPONENT RuntimeLibraries
     )
 

--- a/README.md
+++ b/README.md
@@ -5,10 +5,9 @@ encapsulates [pyradiomics](https://github.com/radiomics/pyradiomics) library,
 which in turn implements calculation of a variety of
 [radiomics](http://radiomics.github.io) features.
 
-Pending resolution of packaging issues, SlicerRadiomics is not currently 
-distributed as an extension via the 3D Slicer ExtensionManager (we expect to
-have this resolved in the near future). You can however use this extension if
-you build SlicerRadiomics from source.
+# Install instructions
+
+SlicerRadiomics is currently distributed as an extension via the 3D Slicer ExtensionManager.
 
 # Build instructions
 
@@ -38,9 +37,13 @@ $ cd SlicerRadiomics-build; ccmake ../SlicerRadiomics
 $ make
 ```
 
-Once the build is completed, you will need to add this path within your extension build tree
-`SlicerRadiomics-build/inner-build/lib/Slicer-4.7/qt-scripted-modules` to the 3D
-Slicer additional modules path (3D Slicer Settings > Modules > Additional module paths).
+* Package the extension
+```
+$ cd inner-build
+$ make package
+```
+
+Once completed, you can install the [extension from file](https://www.slicer.org/wiki/Documentation/Nightly/SlicerApplication/ExtensionsManager#Installing_an_extension_without_network_connection).
 
 # Acknowledgments
 


### PR DESCRIPTION
This commit updates the extension build system so that it installs
pyradiomics and its dependencies in its own directory and package it
along side with the SlicerRadiomics scripted module.