### PR TITLE
Allow fractal bin widths

### DIFF
--- a/SlicerRadiomics/SlicerRadiomics.py
+++ b/SlicerRadiomics/SlicerRadiomics.py
@@ -153,8 +153,8 @@ class SlicerRadiomicsWidget(ScriptedLoadableModuleWidget):
     # bin width, defaults to 25
     self.binWidthSliderWidget = ctk.ctkSliderWidget()
     self.binWidthSliderWidget.singleStep = 1
-    self.binWidthSliderWidget.decimals = 0
-    self.binWidthSliderWidget.minimum = 1
+    self.binWidthSliderWidget.decimals = 2
+    self.binWidthSliderWidget.minimum = 0.01
     self.binWidthSliderWidget.maximum = 100
     self.binWidthSliderWidget.value = 25
     self.binWidthSliderWidget.toolTip = 'Set the bin width'


### PR DESCRIPTION
Allow for fractal bin widths, minimum value is now 0.01, with smallest step size also being 0.01.