### PR TITLE
Add parameter file support

### DIFF
--- a/SlicerRadiomics/SlicerRadiomics.py
+++ b/SlicerRadiomics/SlicerRadiomics.py
@@ -688,11 +688,12 @@ class SlicerRadiomicsTest(ScriptedLoadableModuleTest):
                  ('lung1_binary.seg.nrrd', slicer.util.loadSegmentation),
                  ('lung1.seg_0.vtp', None),
                  ('lung1.seg_1.vtp', None),
-                 ('lung1_surface.seg.vtm', slicer.util.loadSegmentation))
+                 ('lung1_surface.seg.vtm', slicer.util.loadSegmentation),
+                 ('Params.yaml', None))
 
     for item, loader in dataItems:
       url = dataURLPrefix + '-' + dataRelease + '/' + item
-      filePath = slicer.app.temporaryPath + '/' + item
+      filePath = os.path.join(slicer.app.temporaryPath, item)
       if not os.path.exists(filePath) or os.stat(filePath).st_size == 0:
         self.logger.info('Requesting download %s from %s...\n' % (item, url))
         self.assertTrue(urllib.urlretrieve(url, filePath), 'Failed to download from ' + url)
@@ -707,6 +708,8 @@ class SlicerRadiomicsTest(ScriptedLoadableModuleTest):
     labelmapNode = slicer.util.getNode(pattern='lung1_label')
     binaryNode = slicer.util.getNode(pattern='lung1_binary')
     surfaceNode = slicer.util.getNode(pattern='lung1_surface')
+
+    parameterFile = os.path.join(slicer.app.temporaryPath, 'Params.yaml')
 
     logic = SlicerRadiomicsLogic()
     self.assertIsNotNone(logic.hasImageData(grayscaleNode))
@@ -728,5 +731,13 @@ class SlicerRadiomicsTest(ScriptedLoadableModuleTest):
       slicer.mrmlScene.AddNode(tableNode)
       logic.exportToTable(featuresDict, tableNode)
       logic.showTable(tableNode)
+
+    featuresDict = logic.runWithParameterFile(grayscaleNode, labelmapNode, binaryNode, parameterFile)
+
+    tableNode = slicer.vtkMRMLTableNode()
+    tableNode.SetName('lung1_label and ' + binaryNode.GetName() + ' customized with Params.yaml')
+    slicer.mrmlScene.AddNode(tableNode)
+    logic.exportToTable(featuresDict, tableNode)
+    logic.showTable(tableNode)
 
     self.delayDisplay('Test passed!')

--- a/SlicerRadiomics/SlicerRadiomics.py
+++ b/SlicerRadiomics/SlicerRadiomics.py
@@ -293,7 +293,7 @@ class SlicerRadiomicsWidget(ScriptedLoadableModuleWidget):
 
     # Pathe edit to select parameter file
     self.parameterFilePathLineEdit = ctk.ctkPathLineEdit(filters=ctk.ctkPathLineEdit.Files)
-    parameterCustomizationFormLayout.addRow("Paramater File", self.parameterFilePathLineEdit)
+    parameterCustomizationFormLayout.addRow("Parameter File", self.parameterFilePathLineEdit)
 
   def _addOutputSection(self):
     outputCollapsibleButton = ctk.ctkCollapsibleButton()


### PR DESCRIPTION
Update the user interface (SlicerRadiomicsWidget) to optionally extract features using a PyRadiomics Parameter File.

- Group the 3 different types of customization (Feature Class, filter and settings) together into 1 groupbox
- Add radiobuttons to toggle between manual customization (using UI elements) and parameter file customization (using a parameter file)
- On toggle, hide to non-selected group box
- When in parameter file customization mode, disable the `Apply` button so long as the paramter file path element does not contain an existing file
- Split the setup function into separate functions per section to improve readability

Update the logic (SlicerRadiomicsLogic) to support the parameter file

- Add a second run function: `runWithParameterFile`
- Instantiate the extractor in the respective run functions
- Decode the labelNode and Segementation node in the `calculateFeatures` Function

Add a test running SlicerRadiomicsLogic with an example parameters file