### PR TITLE
ENH: Update CLI definition

### DIFF
--- a/SlicerRadiomicsCLI/SlicerRadiomicsCLI
+++ b/SlicerRadiomicsCLI/SlicerRadiomicsCLI
@@ -1,7 +1,0 @@
-#!/usr/bin/env sh
-python_interpreter=`which python-real`
-if [ -z "$python_interpreter" ]; then
-  python_interpreter=`which python`
-fi
-
-$python_interpreter "$0Script" $*

--- a/SlicerRadiomicsCLI/SlicerRadiomicsCLI.bat
+++ b/SlicerRadiomicsCLI/SlicerRadiomicsCLI.bat
@@ -1,9 +1,0 @@
-SET PYTHON_INTERPRETER=python-real.exe
-REM Check if python-real exists: this is the case of installed version of Slicer
-where /q %PYTHON_INTERPRETER%
-IF ERRORLEVEL 1 (
-	REM python-real does not exist! Maybe running from a build-tree? in that case, use python.exe
-	SET PYTHON_INTERPRETER=python.exe
-)
-
-%PYTHON_INTERPRETER% %~dp0SlicerRadiomicsCLIScript %*

--- a/SlicerRadiomicsCLI/SlicerRadiomicsCLI.py
+++ b/SlicerRadiomicsCLI/SlicerRadiomicsCLI.py
@@ -10,6 +10,18 @@ if __name__ == '__main__':
     with open(__file__[:-6] + '.xml', 'r') as xmlFP:  # Cut off "Script" from filename
       print(xmlFP.read())
   else:
+    # Check if old-style label argument is provided
+    if '--label' in sys.argv:
+      label_idx = sys.argv.index('--label')
+      # get the value for the label
+      label = sys.argv[label_idx + 1]
+      # Remove the old-style command argument and value
+      sys.argv.pop(label_idx + 1)
+      sys.argv.pop(label_idx)
+
+      # append new style
+      sys.argv.append('--setting=label:' + label)
+
     sys.argv.append('--format=csv')  # Append this format to ensure a csv return format (default is txt)
     sys.argv.append('--verbosity=4')  # Print out logging with level INFO and higher
     parse_args()  # Entry point for the "pyradiomics" script

--- a/SlicerRadiomicsCLI/SlicerRadiomicsCLI.xml
+++ b/SlicerRadiomicsCLI/SlicerRadiomicsCLI.xml
@@ -32,7 +32,7 @@
       <description><![CDATA[YAML or JSON structured file defining the customization that is to be applied.]]></description>
     </file>
     <integer>
-      <longflag alias="l">label</longflag>
+      <longflag>label</longflag>
       <label>ROI label value</label>
       <minimum>1</minimum>
       <maximum>255</maximum>

--- a/cmake/SlicerRadiomicsAddCLI.cmake
+++ b/cmake/SlicerRadiomicsAddCLI.cmake
@@ -77,25 +77,16 @@ function(SlicerRadiomicsAddCLI)
     endif()
   endforeach()
 
-  set(cli_files
-    "${MY_NAME}.xml"
-    "${MY_NAME}Script"
-    )
+  set(cli_file "${MY_NAME}.xml" )
 
-  if(WIN32)
-    set(cli_script "${MY_NAME}.bat")
-  else()
-    set(cli_script "${MY_NAME}")
-  endif()
+  set(cli_script "${MY_NAME}.py")
 
   set(build_dir ${SlicerExecutionModel_DEFAULT_CLI_RUNTIME_OUTPUT_DIRECTORY}/${CMAKE_CFG_INTDIR})
   set(copy_commands )
-  foreach(cli_file IN LISTS cli_files)
-    list(APPEND copy_commands
+
+  list(APPEND copy_commands
       COMMAND ${CMAKE_COMMAND} -E copy_if_different ${cli_file} ${build_dir}/${cli_file}
       )
-  endforeach()
-
   list(APPEND copy_commands
     COMMAND ${CMAKE_COMMAND} -E copy_if_different ${cli_script} ${build_dir}/${cli_script}
     )
@@ -106,7 +97,7 @@ function(SlicerRadiomicsAddCLI)
     COMMENT "Copying ${MY_NAME} files into build directory"
     )
 
-  install(FILES ${cli_files}
+  install(FILES ${cli_file}
     DESTINATION ${SlicerExecutionModel_DEFAULT_CLI_INSTALL_RUNTIME_DESTINATION}
     COMPONENT RuntimeLibraries
     )
@@ -117,10 +108,10 @@ function(SlicerRadiomicsAddCLI)
     )
 
   if(NOT WIN32)
-    add_custom_target(SetPermissions${MY_NAME}ShellScript ALL
-      COMMAND chmod u+x ${build_dir}/${MY_NAME}
+    add_custom_target(SetPermissions${MY_NAME}CLI ALL
+      COMMAND chmod u+x ${build_dir}/${cli_script}
       WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-      COMMENT "Setting Executable (User) permission for ${MY_NAME} in build directory"
+      COMMENT "Setting Executable (User) permission for ${cli_script} in build directory"
       DEPENDS Copy${MY_NAME}Scripts
     )
   endif()


### PR DESCRIPTION
Remove use .bat and .sh wrapper script, and instead define the CLI entry point as a python script.
This makes use of the new Slicer functionality described in [Slicer#894](https://github.com/Slicer/Slicer/pull/894) and implemented in r27143-r27145.

This fixes #43.

Additionally, check if a `--label <label>` argument is present, and if so, update it to the new-style: `--setting=label:<label>`. Parameter `--label` is deprecated by PR [PyRadiomics#347](https://github.com/Radiomics/pyradiomics/pull/347).

TODO:
- [ ] Test if updates to SlicerRadiomicsAddCLI.cmake work.