### PR TITLE
BUG: Fix failing test

### DIFF
--- a/SlicerRadiomics/SlicerRadiomics.py
+++ b/SlicerRadiomics/SlicerRadiomics.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 from itertools import chain
 import json
 import os

--- a/SlicerRadiomicsCLI/SlicerRadiomicsCLI.py
+++ b/SlicerRadiomicsCLI/SlicerRadiomicsCLI.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python-real
 # -*- coding: utf-8 -*-
 
+from __future__ import print_function
 import sys
 
 from radiomics.scripts import parse_args


### PR DESCRIPTION
This should fix the [failing test](http://slicer.cdash.org/testDetails.php?test=9620633&build=1606047) for Slicer 4.10.

Without this import certain use cases will fail in python 2.7:
```log
>>> print('.', end='')
  File "<console>", line 1
    print('.', end='')
                  ^
SyntaxError: invalid syntax
```
```log
>>> from __future__ import print_function
>>> print('.', end='')
.
```
You will see that the import was included in all necessary files in the Slicer repo with this commit https://github.com/Slicer/Slicer/commit/08c6cd78fd25166773a35269ecd2f2c4fc2ea850