### PR TITLE
BUG: Make usage of next python 2 and 3 compatible

### DIFF
--- a/SlicerRadiomics/SlicerRadiomics.py
+++ b/SlicerRadiomics/SlicerRadiomics.py
@@ -534,7 +534,7 @@ class SlicerRadiomicsLogic(ScriptedLoadableModuleLogic):
   def _startCLI(self, firstRun=False):
     try:
       # Get the next segmentation ROI
-      labelName, labelNode, label_idx, imageNode = self._labelGenerators.__next__()
+      labelName, labelNode, label_idx, imageNode = next(self._labelGenerators)
 
       self.logger.info('Starting RadiomicsCLI for %s', labelName)
 


### PR DESCRIPTION
This fixes a [failing test](http://slicer.cdash.org/testDetails.php?test=9643576&build=1607904) for Slicer 4.10. 

`next(obj)` is python 2.6+ and python 3 compatible while the change to `__next__()` in https://github.com/Radiomics/SlicerRadiomics/commit/a1c806b98a834f0e33b176d048a754be352d1021 was only python 3 compatible.