### PR TITLE
Get sitk address by node not name (more robust)

### DIFF
--- a/SlicerRadiomics/SlicerRadiomics.py
+++ b/SlicerRadiomics/SlicerRadiomics.py
@@ -491,7 +491,7 @@ class SlicerRadiomicsLogic(ScriptedLoadableModuleLogic):
   # Label generators to generate single ROI labels from either labelmapNode or segmentationNode input
   @staticmethod
   def _getLabelGeneratorFromLabelMap(labelNode, imageNode):
-    combinedLabelImage = sitk.ReadImage(sitkUtils.GetSlicerITKReadWriteAddress(labelNode.GetName()))
+    combinedLabelImage = sitk.ReadImage(sitkUtils.GetSlicerITKReadWriteAddress(labelNode))
     combinedLabelArray = sitk.GetArrayFromImage(combinedLabelImage)
     labels = numpy.unique(combinedLabelArray)
 


### PR DESCRIPTION
Making this a PR since I'm editing in browser and don't have it installed to test.

Special characters in name like * or [] cause problems.

See report here: https://discourse.slicer.org/t/radiomics-problem-for-vue-images/11207/3

Method takes either name or node directly, so use node not name.

https://github.com/Slicer/Slicer/blob/47deb76d7556e40de4e25e585c4b24a63a153da5/Base/Python/sitkUtils.py#L44