### PR TITLE
COMP: Update python install to disable script location warnings

### DIFF
--- a/SuperBuild/External_python-pyradiomics.cmake
+++ b/SuperBuild/External_python-pyradiomics.cmake
@@ -54,6 +54,7 @@ if(NOT ${CMAKE_PROJECT_NAME}_USE_SYSTEM_${proj})
         CC=${CMAKE_C_COMPILER}
       ${wrapper_script} ${PYTHON_EXECUTABLE} -m pip install . ${_no_binary}
         --prefix ${python_packages_DIR_NATIVE_DIR}
+        --no-warn-script-location
     )
 
   ExternalProject_Add(${proj}


### PR DESCRIPTION
This commit addresses warnings like the following:

```
  WARNING: The script pyradiomics is installed in '/work/Preview/S-0-E-b/SlicerRadiomics-build/python-packages-install/bin' which is not on PATH.
  Consider adding this directory to PATH or, if you prefer to suppress this warning, use --no-warn-script-location.
```